### PR TITLE
DateTimeParser bug and some other small changes

### DIFF
--- a/Capstone/Actions/ReminderAction.cs
+++ b/Capstone/Actions/ReminderAction.cs
@@ -209,7 +209,7 @@ namespace Capstone.Actions
         {
             // it's pretty hard to figure out which reminder to edit and which fields need to be edited, so direct the users to the reminders page
             this.ClearArea();
-            string text = "For now, editing reminders through voice is not supported. You can edit an reminder by going to the reminders page, finding the reminder you want to edit, and clicking the \"edit\" button.";
+            string text = "For now, editing reminders through voice is not supported. You can edit a reminder by going to the reminders page, finding the reminder you want to edit, and clicking the \"edit\" button.";
             string ssmlText = new SSMLBuilder().Prosody(text, pitch: "+2%", contour: "(10%,-2%) (40%, -3%) (80%, +3%)").Build();
             TextToSpeechEngine.SpeakInflectedText(this.MediaElement, ssmlText);
             this.ShowMessage(text);

--- a/Capstone/Actions/WeatherAction.cs
+++ b/Capstone/Actions/WeatherAction.cs
@@ -30,7 +30,10 @@ namespace Capstone.Actions
             }
             else if (firstApplicableWeatherInfo == null)
             {
-                TextToSpeechEngine.SpeakText(this.MediaElement, "I could not find any weather info for the date specified. Try making sure that you have location enabled, and that this app can access your location through system settings, privacy, location");
+                this.ClearArea();
+                string message = "I could not find any weather info for the date specified. Try making sure that you have location enabled, and that this app can access your location through system settings, privacy, location";
+                TextToSpeechEngine.SpeakText(this.MediaElement, message);
+                this.ShowMessage(message.Replace("settings, privacy, location", "settings > privacy > location"));
             }
         }
 

--- a/Capstone/Common/DateTimeParser.cs
+++ b/Capstone/Common/DateTimeParser.cs
@@ -258,6 +258,8 @@ namespace Capstone.Common
             text = ReplaceDaytimeNamesWithTimeValue(text);
             DateTime time;
             DateTime date;
+            // will be factored into the final date. This will add to the number of days based on if the user specifies am or pm in the time and a couple other factors
+            var dayOffset = 0;
             try
             {
                 time = ParseTimeFromString(text);
@@ -278,12 +280,21 @@ namespace Capstone.Common
             }
 
             // if date is today, and the time has already passed, shift the time 12 hours forward to hit the next time that time would happen
+            string timePart = GetTimePartOfString(text).ToLower();
             if (now.Year == date.Year && now.Month == date.Month && now.Day == date.Day && now.TimeOfDay >= time.TimeOfDay)
             {
-                time = time.AddHours(12);
+                // if the user specified am or pm, then move the day forward. Else assume they mean the next occurence of the time and move the time forward 12 hours
+                if (!StringUtils.Contains(timePart, "am") && !StringUtils.Contains(timePart, "pm"))
+                {
+                    time = time.AddHours(12);
+                }
+                else
+                {
+                    dayOffset = 1;
+                }
             }
 
-            return new System.DateTime(date.Year, date.Month, date.Day) + time.TimeOfDay;
+            return (new System.DateTime(date.Year, date.Month, date.Day).AddDays(dayOffset)) + time.TimeOfDay;
         }
 
         public static DateTime ParseDateTimeFromText(string text)

--- a/Capstone/Common/DateTimeParser.cs
+++ b/Capstone/Common/DateTimeParser.cs
@@ -287,6 +287,12 @@ namespace Capstone.Common
                 if (!StringUtils.Contains(timePart, "am") && !StringUtils.Contains(timePart, "pm"))
                 {
                     time = time.AddHours(12);
+                    // if time is still less than now, then add another 12 hours
+                    if(now.TimeOfDay >= time.TimeOfDay)
+                    {
+                        time = time.AddHours(12);
+                        dayOffset = 1;
+                    }
                 }
                 else
                 {

--- a/Capstone/DataPrivacyTips.xaml
+++ b/Capstone/DataPrivacyTips.xaml
@@ -14,32 +14,30 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="112"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
             <Button Style="{StaticResource NavigationBackButtonNormalStyle}" Grid.Row="0" Margin="25,10,10,10" Height="62" Width="62" Click="BackButton_OnClick"/>
-
-            <StackPanel Grid.Row="0" HorizontalAlignment="Center">
-                <TextBlock FontWeight="Bold" FontSize="50" Text="Data Privacy Tips"></TextBlock>
-            </StackPanel>
-            <StackPanel Grid.Row="1" Margin="100">
+            <TextBlock Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Left" FontSize="24">Data Privacy Tips</TextBlock>
+            <StackPanel Grid.Row="1" Grid.ColumnSpan="2" Margin="100">
                 <TextBlock FontWeight="Bold" FontSize="30"> <Underline>Internet Browswers</Underline></TextBlock>
                 <TextBlock Height="auto" TextWrapping="Wrap" Margin="100,0,0,0" FontSize="20">
                 We highly recommended installing Brave and using it as your default Web Browser. They do no store any record of your browsing history. 
                 Brave blocks ads and trackers, which make it a faster browser. The key is not to opt-in to their rewards. You can read their 
-                privacy policy.<Hyperlink NavigateUri="https://brave.com/privacy/"> Brave Browser Privacy Policy</Hyperlink> Other web browser alternatives
+                privacy policy. <Hyperlink NavigateUri="https://brave.com/privacy/">Brave Browser Privacy Policy</Hyperlink> Other web browser alternatives
                 include <Hyperlink NavigateUri="https://www.torproject.org/"> Tor</Hyperlink> and 
                 <Hyperlink NavigateUri="https://www.mozilla.org/en-US/firefox/new/"> Firefox.</Hyperlink>
                 </TextBlock>
                 <TextBlock Margin="0, 25, 0,0" FontWeight="Bold" FontSize="30"> <Underline>Search Engines</Underline></TextBlock>
                 <TextBlock Height="auto" TextWrapping="Wrap" Margin="100,0,0,0" FontSize="20">
-                We highly recommend using DuckDuckGo as the primary search engine. They do not 
-            collect or share your personal data and by default do not store cookies. However, they are a business and need to make money, so they will show you an ad related to your search. For example, if
+                We highly recommend using DuckDuckGo as the primary search engine. They do not collect or share your personal data and by default do not store cookies. However, they are a business and need to make money, so they will show you an ad related to your search. For example, if
                 you search for cars, they will show you an advertisement about cars. They promise that they are not collecting and sharing your data. You can read their privacy
-               policy for yourself.<Hyperlink NavigateUri="https://duckduckgo.com/privacy">DuckDuckGo Privacy Policy</Hyperlink></TextBlock>
-                <TextBlock Margin="0, 25, 0,0" FontWeight="Bold" FontSize="30"> <Underline>DNS Settings</Underline></TextBlock>
-                <TextBlock Height="auto" TextWrapping="Wrap" Margin="100,0, 0,0" FontSize="20">TO DO. Not quite sure what this is.</TextBlock>
+               policy for yourself. <Hyperlink NavigateUri="https://duckduckgo.com/privacy">DuckDuckGo Privacy Policy</Hyperlink></TextBlock>
                 <TextBlock Margin="0, 25, 0,0" FontWeight="Bold" FontSize="30"> <Underline>Google</Underline></TextBlock>
                 <TextBlock Height="auto" TextWrapping="Wrap" Margin="100,0,0,0" FontSize="20">
                 Google collects any data about you that they can collect. They most likley know your alternative email addresses, birthday,
-                and other person information without your knowledge. Therefore, it is recommended if you value your priavcy, to immediately 
+                and other personal information without your knowledge. Therefore, it is recommended if you value your privacy, to immediately 
                 stop using as much of their services as you can, and delete as much information as possible. To find out how to delete your information
                 from Google, please click the following link:
                 <Hyperlink NavigateUri="https://support.google.com/websearch/answer/465?co=GENIE.Platform%3DDesktop">Delete Google Activity</Hyperlink>
@@ -50,17 +48,13 @@
                     To stop sending your activity history to Microsoft, select Start , then select Settings  > Privacy > Activity history. On this page, clear the Send my activity history to Microsoft check box.
                 </TextBlock>
 
-                <TextBlock Margin="0, 25, 0,0" FontWeight="Bold" FontSize="30"> <Underline>Libraries Used</Underline></TextBlock>
+                <TextBlock Margin="0, 25, 0,0" FontWeight="Bold" FontSize="30"> <Underline>Libraries We Use</Underline></TextBlock>
                 <TextBlock Height="auto" TextWrapping="Wrap" Margin="100,0,0,0" FontSize="20">
                 In order to be as transparent as possible, we have provided links to the libraries that were used to create this application.
                 </TextBlock>
-
                 <HyperlinkButton Content="Click to go libraries page"
                  Click="HyperlinkButton_Click"
                  HorizontalAlignment="Center"/>
-
-
-
             </StackPanel>
         </Grid>
 

--- a/UnitTests/DateTimeParserTests.cs
+++ b/UnitTests/DateTimeParserTests.cs
@@ -277,5 +277,16 @@ namespace UnitTests
             var actualDate = DateTimeParser.ParseDateTimeFromText(inputText, today);
             Assert.AreEqual(expectedDate, actualDate);
         }
+
+        [TestMethod]
+        public void TestParseDateTimeFromTextShiftsTimeToFutureIfPassed()
+        {
+            var inputString = "set an alarm for 5";
+            // since AM is assumed if PM isn't indicated, we need to ensure that an extra 24 hours is applied to a time that has passed 
+            var startingDate = new DateTime(2020, 1, 1, 17, 0, 0);
+            var expectedDate = new DateTime(2020, 1, 2, 5, 0, 0);
+            var actualDate = DateTimeParser.ParseDateTimeFromText(inputString, startingDate);
+            Assert.AreEqual(expectedDate, actualDate);
+        }
     }
 }

--- a/UnitTests/DateTimeParserTests.cs
+++ b/UnitTests/DateTimeParserTests.cs
@@ -267,5 +267,15 @@ namespace UnitTests
             var actualDate = DateTimeParser.ParseDateTimeFromText(inputText, today);
             Assert.AreEqual(expectedDate, actualDate);
         }
+
+        [TestMethod]
+        public void TestParseDateTimeFromTextDoesNotShiftTimeIfUserSpecifiesAMOrPM()
+        {
+            var today = new DateTime(2020, 1, 1, 13, 0, 0); // january first at 1 pm
+            var inputText = "set an alarm for 9 am";
+            var expectedDate = new DateTime(2020, 1, 2, 9, 0, 0); // january 2nd at 9 am
+            var actualDate = DateTimeParser.ParseDateTimeFromText(inputText, today);
+            Assert.AreEqual(expectedDate, actualDate);
+        }
     }
 }


### PR DESCRIPTION
fixed a bug with the DateTimeParser where specifying AM/PM would not work if the time had already passed today (e.g. saying "set an alarm for 9 am" after 9 am would set the alarm for 9 pm since that was the next occurrence of that time). Now if the user specifies AM/PM and it's already passed that time, it shifts the day forward by one. Now this lets us do things like set alarms for the next morning if it's already in the evening. 

Also fixed some spelling issues, and removed the dns settings section from the data privacy screen. 