### PR TITLE
Turn-based system for speech recognition

### DIFF
--- a/Capstone/Actions/ActionRouter.cs
+++ b/Capstone/Actions/ActionRouter.cs
@@ -25,6 +25,7 @@ namespace Capstone.Actions
             SetUpInternetSearchBranches();
             SetUpJokeBranches();
             SetUpDirectBobQuestionBranches();
+            SetUpMiscBranches();
             IsSetup = true;
         }
 
@@ -155,6 +156,16 @@ namespace Capstone.Actions
                 {"do", whatCanYouDoDict }
             };
             actionTree.Add("you", directQuestions);
+        }
+
+        private static void SetUpMiscBranches()
+        {
+            Func<string, Action> repeatAfterMeAction = (commandText) => new RepeatAfterMeAction(commandText);
+            var repeatAfterMeDict = new Dictionary<string, dynamic>()
+            {
+                {"me", repeatAfterMeAction}
+            };
+            actionTree.Add("repeat", repeatAfterMeDict);
         }
 
         /// <summary>

--- a/Capstone/Actions/RepeatAfterMeAction.cs
+++ b/Capstone/Actions/RepeatAfterMeAction.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Capstone.Common;
+using Capstone.SpeechRecognition;
+
+namespace Capstone.Actions
+{
+    public class RepeatAfterMeAction : Action
+    {
+        public RepeatAfterMeAction(string CommandString)
+        {
+            this.CommandString = CommandString;
+        }
+
+        public override async void PerformAction()
+        {
+            Action<string> repeatAction = (text) =>
+            {
+                this.ClearArea();
+                TextToSpeechEngine.SpeakText(this.MediaElement, $"{text}");
+                this.ShowMessage($"You said {text}");
+            };
+            var executedSuccessfully = await SpeechRecognitionManager.RequestListen(this.GetType(), repeatAction);
+        }
+    }
+}

--- a/Capstone/Actions/RepeatAfterMeAction.cs
+++ b/Capstone/Actions/RepeatAfterMeAction.cs
@@ -24,6 +24,13 @@ namespace Capstone.Actions
                 this.ShowMessage($"You said {text}");
             };
             var executedSuccessfully = await SpeechRecognitionManager.RequestListen(this.GetType(), repeatAction);
+            if (!executedSuccessfully)
+            {
+                this.ClearArea();
+                string message = "Something went wrong with listening to you, so I cannot repeat after you. Do you have voice activation set to off in the app settings or system settings?";
+                TextToSpeechEngine.SpeakText(this.MediaElement, message);
+                this.ShowMessage(message);
+            }
         }
     }
 }

--- a/Capstone/Capstone.csproj
+++ b/Capstone/Capstone.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Actions\DirectionsAction.cs" />
     <Compile Include="Actions\JokeAction.cs" />
     <Compile Include="Actions\ReminderAction.cs" />
+    <Compile Include="Actions\RepeatAfterMeAction.cs" />
     <Compile Include="Actions\TimeAction.cs" />
     <Compile Include="Actions\VoiceMemoAction.cs" />
     <Compile Include="Actions\WeatherAction.cs" />
@@ -141,6 +142,7 @@
     <Compile Include="Models\Joke.cs" />
     <Compile Include="Common\AudioRecorder.cs" />
     <Compile Include="Helpers\VoiceMemoUIHelper.cs" />
+    <Compile Include="SpeechRecognition\SpeechRecognitionManager.cs" />
     <Compile Include="SpeechRecognition\SpeechRecognitionUtils.cs" />
     <Compile Include="Common\StoredProcedures.cs" />
     <Compile Include="Common\DateTimeParser.cs" />

--- a/Capstone/Common/Utils.cs
+++ b/Capstone/Common/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Capstone.Models;
 using Windows.UI.Core;
 
 namespace Capstone.Common
@@ -23,6 +24,13 @@ namespace Capstone.Common
         public static async void RunOnMainThread(Action actionToRun)
         {
             await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => actionToRun.Invoke());
+        }
+
+        public static bool IsListeningSettingEnabled()
+        {
+            Setting voiceRecognitionSetting = StoredProcedures.QuerySettingByName("Voice Activation");
+            SettingOption chosenSetting = voiceRecognitionSetting.GetSelectedOption();
+            return chosenSetting != null && chosenSetting.DisplayName == "Enabled";
         }
     }
 }

--- a/Capstone/MainPage.xaml.cs
+++ b/Capstone/MainPage.xaml.cs
@@ -159,7 +159,7 @@ namespace Capstone
             {
                 if (await AudioCapturePermissions.RequestMicrophonePermission())
                 {
-                    SpeechRecognitionUtils.Start(performActionFromCommandBoxText, this.CommandBox);
+                    SpeechRecognitionManager.StartListeningForMainPage(performActionFromCommandBoxText, this.CommandBox);
                 }
                 else
                 {

--- a/Capstone/MainPage.xaml.cs
+++ b/Capstone/MainPage.xaml.cs
@@ -153,9 +153,7 @@ namespace Capstone
 
         private async void RequestMicrophoneAcessIfUserWantsVoiceDetection()
         {
-            Setting voiceRecognitionSetting = StoredProcedures.QuerySettingByName("Voice Activation");
-            SettingOption chosenSetting = voiceRecognitionSetting.GetSelectedOption();
-            if (chosenSetting != null && chosenSetting.DisplayName == "Enabled")
+            if (Utils.IsListeningSettingEnabled())
             {
                 if (await AudioCapturePermissions.RequestMicrophonePermission())
                 {

--- a/Capstone/SpeechRecognition/SpeechRecognitionManager.cs
+++ b/Capstone/SpeechRecognition/SpeechRecognitionManager.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Capstone.Common;
+using Capstone.Models;
 using Windows.Media.SpeechRecognition;
 using Windows.UI.Xaml.Controls;
 
@@ -24,7 +26,7 @@ namespace Capstone.SpeechRecognition
         public static async Task<bool> RequestListen(Type callerType, Action<string> callbackFunction)
         {
             // if the current listener is the main screen, then it's fine to interrupt. Otherwise we need to check if the current listener is done
-            if (typeof(MainPage) != CurrentListener && !IsCurrentListenerDone)
+            if (typeof(MainPage) != CurrentListener && !IsCurrentListenerDone || !Utils.IsListeningSettingEnabled())
             {
                 // we can't listen, so return false
                 return false;
@@ -75,13 +77,20 @@ namespace Capstone.SpeechRecognition
         /// </summary>
         private static void StartListeningForMainPage()
         {
-            if (MainPageFunction != null && MainPageTextBox != null)
+            if (Utils.IsListeningSettingEnabled())
             {
-                // the main page takes priority over everything when it comes to listening, so force stop
-                SpeechRecognitionUtils.Stop();
-                CurrentListener = typeof(MainPage);
-                IsCurrentListenerDone = false;
-                SpeechRecognitionUtils.StartLooping(MainPageFunction, MainPageTextBox);
+                if (MainPageFunction != null && MainPageTextBox != null)
+                {
+                    // the main page takes priority over everything when it comes to listening, so force stop
+                    SpeechRecognitionUtils.Stop();
+                    CurrentListener = typeof(MainPage);
+                    IsCurrentListenerDone = false;
+                    SpeechRecognitionUtils.StartLooping(MainPageFunction, MainPageTextBox);
+                }
+            }
+            else
+            {
+                TextToSpeechEngine.SpeakText(new MediaElement(), "Sorry, but something went wrong with setting up your microphone. You cannot use me through speech, but you can still use the command bar at the bottom of the screen.");
             }
         }
     }

--- a/Capstone/SpeechRecognition/SpeechRecognitionManager.cs
+++ b/Capstone/SpeechRecognition/SpeechRecognitionManager.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.Media.SpeechRecognition;
+using Windows.UI.Xaml.Controls;
+
+namespace Capstone.SpeechRecognition
+{
+    public class SpeechRecognitionManager
+    {
+        // the current class that has the listener's attention
+        private static Type CurrentListener { get; set; }
+        // used by the current listener to tell it when the current listener is done listening
+        public static bool IsCurrentListenerDone { get; set; }
+        // the reference to what the objects the main page uses when listening
+        private static Action<string> MainPageFunction { get; set; }
+        private static TextBox MainPageTextBox { get; set; }
+
+        /// <summary>
+        /// Attempts to request access to the speech recognizer to recognize text. Access to the speech recognizer is not guaranteed, and a boolean <code>false</code> will be returned if access is rejected
+        /// </summary>
+        /// <param name="callerType">The type of the class calling this method</param>
+        /// <param name="callbackFunction">the function to be invoked with the recognized text.</param>
+        /// <returns>true if access was granted and no errors were thrown, false otherwise</returns>
+        public static async Task<bool> RequestListen(Type callerType, Action<string> callbackFunction)
+        {
+            // if the current listener is the main screen, then it's fine to interrupt. Otherwise we need to check if the current listener is done
+            if (typeof(MainPage) != CurrentListener && !IsCurrentListenerDone)
+            {
+                // we can't listen, so return false
+                return false;
+            }
+            else
+            {
+                // stop the current speech recognition session
+                SpeechRecognitionUtils.Stop();
+                try
+                {
+                    // set the class that's listening
+                    IsCurrentListenerDone = false;
+                    CurrentListener = callerType;
+                    SpeechRecognitionResult result = await SpeechRecognitionUtils.ListenOnceAsync();
+                    SpeechRecognitionUtils.Stop();
+                    IsCurrentListenerDone = true;
+                    // make the main page listen again
+                    StartListeningForMainPage();
+                    // now call the callback function
+                    callbackFunction.Invoke(result.Text);
+                    return true; // successfully listened and did the command
+                }
+                catch (Exception)
+                {
+                    return false; // something went wrong with listening
+                }
+            }
+        }
+
+        /// <summary>
+        /// Starts the speech recognition for the main page, using the passed <paramref name="callbackFunction"/> and the passed <paramref name="textBox"/>
+        /// </summary>
+        /// <param name="callbackFunction"></param>
+        /// <param name="textBox"></param>
+        public static void StartListeningForMainPage(Action<string> callbackFunction, TextBox textBox)
+        {
+            // the main page takes priority over everything when it comes to listening, so force stop
+            SpeechRecognitionUtils.Stop();
+            CurrentListener = typeof(MainPage);
+            IsCurrentListenerDone = false;
+            MainPageFunction = callbackFunction;
+            MainPageTextBox = textBox;
+            SpeechRecognitionUtils.StartLooping(MainPageFunction, MainPageTextBox);
+        }
+
+        /// <summary>
+        /// should only be called after <see cref="StartListeningForMainPage(Action{string}, TextBox)"/> has been called since the main page was navigated to
+        /// </summary>
+        private static void StartListeningForMainPage()
+        {
+            if (MainPageFunction != null && MainPageTextBox != null)
+            {
+                // the main page takes priority over everything when it comes to listening, so force stop
+                SpeechRecognitionUtils.Stop();
+                CurrentListener = typeof(MainPage);
+                IsCurrentListenerDone = false;
+                SpeechRecognitionUtils.StartLooping(MainPageFunction, MainPageTextBox);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a system to allow different parts of the application to listen, not just the main page. An example of this is the new action I added to test this, the `RepeatAfterMeAction`. It works by stopping all current speech recognition and starting it up again to listen one single time. After it has listened, listening abilities are then returned back to the main page. 